### PR TITLE
Fix errors with building the docs

### DIFF
--- a/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
+++ b/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
@@ -91,7 +91,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
     }
 
     /**
-     * returns family.apply(index) -> algebra.family.apply(index)
+     * returns family.apply(index) -&gt; algebra.family.apply(index)
      */
     public IntFunction<RewriteResult<?, ?>> fold(final Algebra algebra) {
         return index -> {

--- a/src/main/java/com/mojang/datafixers/types/templates/TypeTemplate.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/TypeTemplate.java
@@ -32,16 +32,16 @@ public interface TypeTemplate {
     }
 
     /**
-     * returned optic will accept template<family<index>> with the input template, and will return the same with the returned template
-     * (template, optic) = Left(result)
-     * this.apply(family).apply(index) == optic.sType
-     * template.apply(family).apply(index) == optic.tType
+     * returned optic will accept {@code template<family<index>>} with the input template, and will return the same with the returned template.
+     * <p>{@code (template, optic) = Left(result)}
+     * <p>{@code this.apply(family).apply(index) == optic.sType}
+     * <p>{@code template.apply(family).apply(index) == optic.tType}
      */
     <A, B> Either<TypeTemplate, Type.FieldNotFoundException> findFieldOrType(final int index, @Nullable String name, Type<A> type, Type<B> resultType);
 
     /**
-     * constraint: family, argFamily and resFamily are matched
-     * result.function(i) :: this.apply(function.argFamily()).apply(i) -> this.apply(function.resFamily()).apply(i)
+     * constraint: family, argFamily and resFamily are matched.
+     * <p>{@code result.function(i) :: this.apply(function.argFamily()).apply(i) -> this.apply(function.resFamily()).apply(i)}
      */
     IntFunction<RewriteResult<?, ?>> hmap(final TypeFamily family, final IntFunction<RewriteResult<?, ?>> function);
 

--- a/src/main/java/com/mojang/serialization/JsonOps.java
+++ b/src/main/java/com/mojang/serialization/JsonOps.java
@@ -405,7 +405,8 @@ public class JsonOps implements DynamicOps<JsonElement> {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
      * @implSpec This implementation returns whether this object uses compressed serialization.
      * @see #INSTANCE
      * @see #COMPRESSED

--- a/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java
+++ b/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java
@@ -30,7 +30,7 @@ public class KeyDispatchCodec<K, V> extends MapCodec<V> {
     }
 
     /**
-     * Assumes codec(type(V)) is Codec<V>
+     * Assumes {@code codec(type(V))} is {@code Codec<V>}
      */
     public KeyDispatchCodec(final String typeKey, final Codec<K> keyCodec, final Function<? super V, ? extends DataResult<? extends K>> type, final Function<? super K, ? extends DataResult<? extends Codec<? extends V>>> codec) {
         this(typeKey, keyCodec, type, codec, v -> getCodec(type, codec, v));


### PR DESCRIPTION
- Fixed inheritDoc not being in brackets in JsonOps.compressMaps as it's an inline tag
- Fixed errors with < and > in Mojang docs
- Fixed TypeTemplate "docs" (= laws) not having paragraphs